### PR TITLE
Add array/conditional helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/) and
 the format of [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
+### Added
+- `LambdaMethods.ArrayTransform` overloads for two and three input arrays (`ARRAY_TRANSFORM(lambda, a, b[, c])`), enabling element-wise transforms across parallel arrays (e.g. `TRANSFORM(x, y -> (y - x), starts, ends)`).
+- `ArrayMethods.At` — 1-based Firebolt array subscript access (`arr[index]`).
+- `ArrayMethods.AsSqlArray` — builds a single-element array literal (`[value]`) from a scalar column.
+- `ConditionalMethods.NullIf` — `NULLIF(value, compare)`, primarily for guarding divisors against zero.
+
+### Fixed
+- `LambdaBuilder` now emits `IS NULL` / `IS NOT NULL` for `== null` / `!= null` comparisons instead of the semantically-incorrect `= NULL` / `!= NULL`.
+- `LambdaBuilder` now supports arithmetic (`+`, `-`, `*`, `/`) and boolean (`AND`, `OR`) operators inside array-lambda bodies.
 
 ## [5.0.0] - 2025-11-24
 - Initial release

--- a/src/Similarweb.LinqToDb.Firebolt/Extensions/ArrayMethods.cs
+++ b/src/Similarweb.LinqToDb.Firebolt/Extensions/ArrayMethods.cs
@@ -217,6 +217,32 @@ public static partial class ArrayMethods
     ) => throw new LinqToDBException("Not supported on client");
 
     /// <summary>
+    /// <para>Implementation for Firebolt <see href="https://docs.firebolt.io/sql_reference/data-types/array.html">array subscript</see> access (<c>arr[index]</c>).</para>
+    /// <para>Index is <b>1-based</b>, matching Firebolt semantics.</para>
+    /// </summary>
+    /// <typeparam name="T">Type of the array items.</typeparam>
+    /// <param name="array">The array.</param>
+    /// <param name="index">1-based element index.</param>
+    /// <returns>The element at the given 1-based index.</returns>
+    [Sql.Expression(DataProvider.V2Id, "{0}[{1}]", PreferServerSide = true)]
+    public static T At<T>(
+        this T[] array,
+        [ExprParameter] int index
+    ) => array[index - 1];
+
+    /// <summary>
+    /// <para>Builds a single-element Firebolt array literal (<c>[value]</c>) from a scalar.</para>
+    /// <para>Useful for composing array-lambda pipelines from scalar columns.</para>
+    /// </summary>
+    /// <typeparam name="T">Type of the element.</typeparam>
+    /// <param name="value">The element to wrap.</param>
+    /// <returns>A single-element array.</returns>
+    [Sql.Expression(DataProvider.V2Id, "[{0}]", PreferServerSide = true)]
+    public static T[] AsSqlArray<T>(
+        this T value
+    ) => [value];
+
+    /// <summary>
     /// Implements the <see href="https://docs.firebolt.io/sql_reference/functions-reference/array/array-slice.html">ARRAY_SLICE</see> Firebolt method.
     /// </summary>
     /// <typeparam name="T">Type of the array items.</typeparam>

--- a/src/Similarweb.LinqToDb.Firebolt/Extensions/Builders/LambdaBuilder.cs
+++ b/src/Similarweb.LinqToDb.Firebolt/Extensions/Builders/LambdaBuilder.cs
@@ -63,6 +63,14 @@ internal class LambdaBuilder(
         builder.AddExpression(ExpectedLambdaName, sqlExpr.ToString());
         return;
 
+        static bool IsNullConstant(Expression expr)
+        {
+            var unwrapped = expr is UnaryExpression { NodeType: ExpressionType.Convert } convert
+                ? convert.Operand
+                : expr;
+            return unwrapped is ConstantExpression { Value: null };
+        }
+
         string GetOperator(BinaryExpression expr) =>
             expr.NodeType switch
             {
@@ -73,6 +81,12 @@ internal class LambdaBuilder(
                 ExpressionType.Equal => "=",
                 ExpressionType.NotEqual => "!=",
                 ExpressionType.Modulo => "%",
+                ExpressionType.Add => "+",
+                ExpressionType.Subtract => "-",
+                ExpressionType.Multiply => "*",
+                ExpressionType.Divide => "/",
+                ExpressionType.AndAlso => "AND",
+                ExpressionType.OrElse => "OR",
                 _ => throw new LinqToDBException($"Invalid operator: {expr.NodeType}"),
             };
 
@@ -108,6 +122,16 @@ internal class LambdaBuilder(
                             break;
                     }
 
+                    break;
+                case BinaryExpression binaryExpr
+                    when binaryExpr.NodeType is ExpressionType.Equal or ExpressionType.NotEqual
+                         && (IsNullConstant(binaryExpr.Left) || IsNullConstant(binaryExpr.Right)):
+                    var operand = IsNullConstant(binaryExpr.Left) ? binaryExpr.Right : binaryExpr.Left;
+                    innerBuilder
+                        .Append('(')
+                        .Append(RecursiveParse(operand))
+                        .Append(binaryExpr.NodeType == ExpressionType.Equal ? " IS NULL" : " IS NOT NULL")
+                        .Append(')');
                     break;
                 case BinaryExpression binaryExpr:
                     var left = RecursiveParse(binaryExpr.Left);

--- a/src/Similarweb.LinqToDb.Firebolt/Extensions/ConditionalMethods.cs
+++ b/src/Similarweb.LinqToDb.Firebolt/Extensions/ConditionalMethods.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using LinqToDB;
+
+namespace Similarweb.LinqToDB.Firebolt.Extensions;
+
+/// <summary>
+/// Implementation for Firebolt <see href="https://docs.firebolt.io/sql_reference/functions-reference/conditional-and-miscellaneous/">conditional functions</see>.
+/// </summary>
+public static class ConditionalMethods
+{
+    /// <summary>
+    /// <para>Implementation for <see href="https://docs.firebolt.io/sql_reference/functions-reference/conditional-and-miscellaneous/nullif.html">NULLIF</see> Firebolt method.</para>
+    /// <para>Returns <c>NULL</c> when <paramref name="value"/> equals <paramref name="compare"/>, otherwise returns <paramref name="value"/>.</para>
+    /// <para>Typical usage is guarding a divisor against zero: <c>x / value.NullIf(0)</c>.</para>
+    /// </summary>
+    /// <typeparam name="T">Value type.</typeparam>
+    /// <param name="value">Value to return when it differs from <paramref name="compare"/>.</param>
+    /// <param name="compare">Value to compare against.</param>
+    /// <returns><c>null</c> when the values are equal, otherwise <paramref name="value"/>.</returns>
+    [Sql.Expression(DataProvider.V2Id, "NULLIF({0}, {1})", PreferServerSide = true)]
+    public static T? NullIf<T>(
+        this T value,
+        T compare
+    )
+        where T : struct
+        => EqualityComparer<T>.Default.Equals(value, compare) ? null : value;
+}

--- a/src/Similarweb.LinqToDb.Firebolt/Extensions/LambdaMethods.cs
+++ b/src/Similarweb.LinqToDb.Firebolt/Extensions/LambdaMethods.cs
@@ -24,6 +24,51 @@ public static class LambdaMethods
     ) => throw new LinqToDBException("Not supported on client");
 
     /// <summary>
+    /// <para>Implementation for <see href="https://docs.firebolt.io/reference-sql/functions-reference/lambda/transform">ARRAY_TRANSFORM</see> Firebolt method over two arrays.</para>
+    /// <para>Applies <paramref name="lambda"/> element-wise to a pair of arrays (zipped by index).</para>
+    /// </summary>
+    /// <typeparam name="TItem">Type of the first array items.</typeparam>
+    /// <typeparam name="TSecond">Type of the second array items.</typeparam>
+    /// <typeparam name="TResult">Type of resulting item.</typeparam>
+    /// <param name="array">First array (provides the first lambda parameter).</param>
+    /// <param name="second">Second array (provides the second lambda parameter).</param>
+    /// <param name="lambda">Transformation applied to each <c>(first, second)</c> pair.</param>
+    /// <returns>A new array with transformed elements.</returns>
+    [Sql.Extension(DataProvider.V2Id, "ARRAY_TRANSFORM({lambda}, {array}, {second})", BuilderType = typeof(LambdaBuilder), TokenName = AnalyticFunctions.FunctionToken, ChainPrecedence = 10, IsAggregate = true, PreferServerSide = true)]
+    public static TResult[] ArrayTransform<TItem, TSecond, TResult>(
+        [ExprParameter] this TItem[] array,
+        [ExprParameter] TSecond[] second,
+        Expression<Func<TItem, TSecond, TResult>> lambda
+    ) => array
+        .Zip(second)
+        .Select(pair => lambda.Compile().Invoke(pair.First, pair.Second))
+        .ToArray();
+
+    /// <summary>
+    /// <para>Implementation for <see href="https://docs.firebolt.io/reference-sql/functions-reference/lambda/transform">ARRAY_TRANSFORM</see> Firebolt method over three arrays.</para>
+    /// <para>Applies <paramref name="lambda"/> element-wise to three arrays (zipped by index).</para>
+    /// </summary>
+    /// <typeparam name="TItem">Type of the first array items.</typeparam>
+    /// <typeparam name="TSecond">Type of the second array items.</typeparam>
+    /// <typeparam name="TThird">Type of the third array items.</typeparam>
+    /// <typeparam name="TResult">Type of resulting item.</typeparam>
+    /// <param name="array">First array (provides the first lambda parameter).</param>
+    /// <param name="second">Second array (provides the second lambda parameter).</param>
+    /// <param name="third">Third array (provides the third lambda parameter).</param>
+    /// <param name="lambda">Transformation applied to each <c>(first, second, third)</c> triple.</param>
+    /// <returns>A new array with transformed elements.</returns>
+    [Sql.Extension(DataProvider.V2Id, "ARRAY_TRANSFORM({lambda}, {array}, {second}, {third})", BuilderType = typeof(LambdaBuilder), TokenName = AnalyticFunctions.FunctionToken, ChainPrecedence = 10, IsAggregate = true, PreferServerSide = true)]
+    public static TResult[] ArrayTransform<TItem, TSecond, TThird, TResult>(
+        [ExprParameter] this TItem[] array,
+        [ExprParameter] TSecond[] second,
+        [ExprParameter] TThird[] third,
+        Expression<Func<TItem, TSecond, TThird, TResult>> lambda
+    ) => array
+        .Zip(second, (first, sec) => (first, sec))
+        .Zip(third, (pair, thi) => lambda.Compile().Invoke(pair.first, pair.sec, thi))
+        .ToArray();
+
+    /// <summary>
     /// <para>Implementation for <see href="https://docs.firebolt.io/sql_reference/functions-reference/array/array-count.html">ARRAY_COUNT</see> Firebolt method.</para>
     /// <para>Counts the number of elements in the array for which <c>lambda.</c> returns <c>TRUE</c>.</para>
     /// </summary>

--- a/tests/Similarweb.LinqToDb.Firebolt.Tests/Linq/ArrayTests.cs
+++ b/tests/Similarweb.LinqToDb.Firebolt.Tests/Linq/ArrayTests.cs
@@ -546,6 +546,38 @@ public class ArrayTests(
 
     #endregion
 
+    #region At (subscript)
+
+    [Fact]
+    public async Task Test_At_OneBasedSubscript()
+    {
+        var rows = await northwind.Context.OrderItems
+            .GroupBy(i => i.OrderId)
+            .Select(group => new
+            {
+                OrderId = group.Key,
+                Arr = group.ArrayAggregate(item => item.ProductId).ToValue(),
+            })
+            .Where(x => x.Arr.ArrayLength() > 0)
+            .Select(x => new
+            {
+                x.OrderId,
+                x.Arr,
+                FirstServer = x.Arr.At(1),
+                LastServer = x.Arr.At(x.Arr.ArrayLength()),
+            })
+            .ToListAsync(token: TestContext.Current.CancellationToken);
+
+        Assert.NotEmpty(rows);
+        foreach (var r in rows)
+        {
+            Assert.Equal(r.Arr[0], r.FirstServer);
+            Assert.Equal(r.Arr[^1], r.LastServer);
+        }
+    }
+
+    #endregion // At (subscript)
+
     #region Slice
 
     [Theory]

--- a/tests/Similarweb.LinqToDb.Firebolt.Tests/Linq/ConditionalTests.cs
+++ b/tests/Similarweb.LinqToDb.Firebolt.Tests/Linq/ConditionalTests.cs
@@ -1,0 +1,54 @@
+using LinqToDB;
+using Similarweb.LinqToDB.Firebolt.Extensions;
+using Similarweb.LinqToDB.Firebolt.Tests.Fixtures;
+using Similarweb.LinqToDB.Firebolt.Tests.Northwind;
+using Xunit;
+
+namespace Similarweb.LinqToDB.Firebolt.Tests.Linq;
+
+/// <summary>
+/// Tests for Firebolt <see href="https://docs.firebolt.io/sql_reference/functions-reference/conditional-and-miscellaneous/">conditional functions</see>.
+/// </summary>
+public class ConditionalTests(
+    ContextFixture<NorthwindContext> northwind
+) : IClassFixture<ContextFixture<NorthwindContext>>, IDisposable, IAsyncDisposable
+{
+    #region NullIf
+
+    [Fact]
+    public async Task Test_NullIf_GuardsDivisorAgainstZero()
+    {
+        var result = await northwind.Context.OrderItems
+            .GroupBy(item => item.OrderId)
+            .Select(group => new
+            {
+                OrderId = group.Key,
+                Count = group.Count(),
+                // NULLIF turns a zero divisor into NULL, so the ratio becomes NULL instead of throwing.
+                Ratio = group.Sum(item => item.Quantity) / (double?)group.Count().NullIf(0),
+            })
+            .ToListAsync(token: TestContext.Current.CancellationToken);
+
+        Assert.NotEmpty(result);
+        Assert.All(result, item => Assert.True(item.Count == 0 ? item.Ratio == null : item.Ratio != null));
+    }
+
+    #endregion // NullIf
+
+    #region Disposing
+
+    public void Dispose()
+    {
+        northwind.LogLastQuery();
+        GC.SuppressFinalize(this);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        northwind.LogLastQuery();
+        GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
+    }
+
+    #endregion // Disposing
+}

--- a/tests/Similarweb.LinqToDb.Firebolt.Tests/Linq/LambdaTests.cs
+++ b/tests/Similarweb.LinqToDb.Firebolt.Tests/Linq/LambdaTests.cs
@@ -285,6 +285,34 @@ public class LambdaTests(
         Assert.All(result, item => Assert.Equal(item.Orders.Select(x => x > 500m ? x : null), item.Filtered));
     }
 
+    [Fact]
+    public async Task Test_ArrayTransform_TwoArrays()
+    {
+        var result = await northwind.Context.OrderItems
+            .GroupBy(item => item.OrderId)
+            .Select(group => new
+            {
+                OrderId = group.Key,
+                Quantities = group.ArrayAggregate(item => item.Quantity).ToValue(),
+                ProductIds = group.ArrayAggregate(item => item.ProductId).ToValue(),
+            })
+            .Select(tuple => new
+            {
+                tuple.OrderId,
+                tuple.Quantities,
+                tuple.ProductIds,
+                Combined = tuple.ProductIds.ArrayTransform(tuple.Quantities, (productId, quantity) => productId * quantity),
+            })
+            .ToListAsync(token: TestContext.Current.CancellationToken);
+
+        Assert.NotEmpty(result);
+        Assert.All(
+            result,
+            item => Assert.Equal(
+                item.ProductIds.Zip(item.Quantities, (productId, quantity) => productId * quantity),
+                item.Combined));
+    }
+
     #endregion // ArrayTransform
 
     #region Disposing

--- a/tests/Similarweb.LinqToDb.Firebolt.Tests/Linq/NewHelpersSqlTests.cs
+++ b/tests/Similarweb.LinqToDb.Firebolt.Tests/Linq/NewHelpersSqlTests.cs
@@ -1,0 +1,113 @@
+using LinqToDB;
+using LinqToDB.Data;
+using Similarweb.LinqToDB.Firebolt;
+using Similarweb.LinqToDB.Firebolt.Extensions;
+using Similarweb.LinqToDB.Firebolt.Tests.Northwind;
+using Xunit;
+
+namespace Similarweb.LinqToDB.Firebolt.Tests.Linq;
+
+/// <summary>
+/// <para>SQL-generation tests for the helpers added to support the Segments traffic-and-engagement conversion.</para>
+/// <para>These assert the produced SQL only (via <see cref="object.ToString"/>) and do not require a live Firebolt connection.</para>
+/// </summary>
+public class NewHelpersSqlTests
+{
+    private static NorthwindContext CreateContext()
+    {
+        Registration.AddDataProvider();
+        var options = new DataOptions()
+            .UseConnectionString(Registration.DataProviderName, "database=db;engine=e;account=a;client_id=x;client_secret=y;env=");
+        return new NorthwindContext(options);
+    }
+
+    [Fact]
+    public void ArrayTransform_TwoArrays_EmitsArrayTransformWithTwoArrayArguments()
+    {
+        using var context = CreateContext();
+
+        var sql = context.OrderItems
+            .GroupBy(item => item.OrderId)
+            .Select(group => new
+            {
+                group.Key,
+                Diffs = group.ArrayAggregate(item => item.Quantity).ToValue()
+                    .ArrayTransform(
+                        group.ArrayAggregate(item => item.ProductId).ToValue(),
+                        (quantity, productId) => productId - quantity),
+            })
+            .ToString();
+
+        Assert.Contains("ARRAY_TRANSFORM(", sql);
+        Assert.Contains("->", sql);
+    }
+
+    [Fact]
+    public void At_EmitsOneBasedSubscript()
+    {
+        using var context = CreateContext();
+
+        var sql = context.OrderItems
+            .GroupBy(item => item.OrderId)
+            .Select(group => new
+            {
+                group.Key,
+                First = group.ArrayAggregate(item => item.Quantity).ToValue().At(1),
+            })
+            .ToString();
+
+        Assert.Contains("[1]", sql);
+    }
+
+    [Fact]
+    public void AsSqlArray_EmitsArrayLiteral()
+    {
+        using var context = CreateContext();
+
+        var sql = context.OrderItems
+            .Select(item => new
+            {
+                item.Id,
+                Wrapped = item.Quantity.AsSqlArray(),
+            })
+            .ToString();
+
+        Assert.Contains("[", sql);
+    }
+
+    [Fact]
+    public void NullIf_EmitsNullIf()
+    {
+        using var context = CreateContext();
+
+        var sql = context.OrderItems
+            .GroupBy(item => item.OrderId)
+            .Select(group => new
+            {
+                group.Key,
+                Share = group.Count().NullIf(0),
+            })
+            .ToString();
+
+        Assert.Contains("NULLIF(", sql);
+    }
+
+    [Fact]
+    public void ArrayCount_WithIsNotNullLambda_EmitsIsNotNull()
+    {
+        using var context = CreateContext();
+
+        var sql = context.OrderItems
+            .GroupBy(item => item.OrderId)
+            .Select(group => new
+            {
+                group.Key,
+                NonNulls = group.ArrayAggregate(int? (item) => item.ProductId).ToValue()
+                    .ArrayCount(value => value != null),
+            })
+            .ToString();
+
+        Assert.Contains("IS NOT NULL", sql);
+        Assert.DoesNotContain("!= NULL", sql);
+    }
+}


### PR DESCRIPTION
Adds the Firebolt helpers required in native LinqToDB:

- ArrayTransform: two- and three-array overloads (ARRAY_TRANSFORM over parallel arrays, e.g. TRANSFORM(x, y -> (y - x), a, b))
- ArrayMethods.At: 1-based array subscript (arr[index])
- ArrayMethods.AsSqlArray: single-element array literal ([value])
- ConditionalMethods.NullIf: NULLIF(value, compare) for divisor guards

Fixes in LambdaBuilder:
- emit IS NULL / IS NOT NULL for == null / != null (was = NULL / != NULL)
- support arithmetic (+ - * /) and boolean (AND/OR) operators in lambdas

Adds offline SQL-generation tests plus Northwind integration tests.